### PR TITLE
Add logstash output to log to logz.io

### DIFF
--- a/pipeline/logstash.conf
+++ b/pipeline/logstash.conf
@@ -26,6 +26,10 @@ filter {
         convert => { "level" => "string" }
         remove_field => [ "@version" ]
     }
+
+    mutate {
+        add_field => { "token" => "${LS_LOGZ_TOKEN}" }
+    }
 }
 
 output {
@@ -38,6 +42,17 @@ output {
         aws_secret_access_key => "${LS_AWS_SECRET_ACCESS_KEY}"
         index                 => "${LS_ENVIRONMENT}-logs-%{+YYYY.MM.dd}"
     }
+
+    tcp {
+	   host => "listener.logz.io"
+	   port => "5052" 
+	   codec => "json_lines" 
+	   ssl_enable => true 
+	   ssl_verify => true
+	   ssl_cert => "/usr/share/logstash/keys/logstash.crt" 
+	   ssl_key => "/usr/share/logstash/keys/logstash.key" 
+	   ssl_cacert => "/usr/share/logstash/keys/TrustExternalCARoot.crt"
+	}
 }
 
 # vim: set sw=4 tw=4 ts=4 et


### PR DESCRIPTION
The LOGZ_TOKEN is provided by logz.io and stored in the k8s secret. The various certificates will also be provided by the secret as a volume mount.